### PR TITLE
Fixes invalid closing xml tag

### DIFF
--- a/src/Api/Employees.php
+++ b/src/Api/Employees.php
@@ -135,7 +135,7 @@ class Employees extends AbstractApi
             $xml .= "<field id=\"{$field}\">{$value}</field>";
         }
 
-        $xml .= "<employee>";
+        $xml .= "</employee>";
 
         return $this->post("employees", $xml);
     }


### PR DESCRIPTION
It appears the closing tag in the `add` method of the `Employees` class was missing a forward slash.